### PR TITLE
Add links as hrefs to node text

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ The plugin is available in the [Gradle plugins repository](https://plugins.gradl
 Kotlin:
 ```kotlin
 plugins {
-  id("io.github.adityabhaskar.dependencygraph") version "0.1.2"
+  id("io.github.adityabhaskar.dependencygraph") version "0.1.3"
 }
 ```
 
 Groovy:
 ```groovy
 plugins {
-  id "io.github.adityabhaskar.dependencygraph" version "0.1.2"
+  id "io.github.adityabhaskar.dependencygraph" version "0.1.3"
 }
 ```
 
@@ -68,14 +68,15 @@ dependencyGraphConfig {
 
 All configuration options are optional with sensible defaults.
 
-| Config option | Type | Description | Default value |
+| Config option | Type | Default value | Description |
 | --- | --- | --- | --- |
-|`graphDirection`| `Direction` | The direction in which the graph should be laid out.<br>Options: <ul> <li><code>Direction.LeftToRight</code></li> <li><code>Direction.TopToBottom</code></li> <li><code>Direction.BottomToTop</code></li> <li><code>Direction.RightToLeft</code></li> </ul>  | `Direction.LeftToRight` |
-| `showLegend` | `ShowLegend` | Whether to show a legend. When enabled, the graph with contain a legend identifying different types of modules — current/root, java/kotlin, Android and multiplatform — and different type of dependencies - direct, indirect & transitive.<br> Options: <ul> <li><code>ShowLegend.Always</code></li> <li><code>ShowLegend.OnlyInRootGraph</code></li> <li><code>ShowLegend.Never</code></li> </ul>| `ShowLegend.OnlyInRootGraph`
-| `graphFileName` | `String` | Name of the file in which the graph is saved. <br> **Note**: <ul> <li>If the provided filename doesn't end in `.md`, then the extension will be appended.</li> <li>Try not to use `-` or any special characters in the file name. This interferes with the mermaid graph format when adding links. If the file name contains anything other than `[a-zA-Z0-9]`, then links will not be added.</li> </ul>|  `dependencyGraph.md` |
-|`ignoreModules`|`List<String>`| A list of modules to be ignored when generating the graph. This may be used, for instance to remove system test modules to see only the production graph.<br>Provide the full path of the modules you want to ignore, e.g. `:live-feature:ui` instead of `:test-ui`. | `emptyList()` |
-| `repoRootUrl` | `String` | Github URL for your repository. E.g. `https://github.com/adityabhaskar/Gradle-dependency-graphs`<br>The URL is used for adding links to modules to allow navigation to a module's subgraph just by clicking on it. If no URL is provided, then links aren't added to the graph.<br>**Note**: Github doesn't support click navigation from mermaid graphs at the moment.| `""` |
-| `mainBranchName`| `String` | Name of your main branch, e.g. `master`.<br>This is combined with the `repoRootUrl` to create clickable URLs. The URLs are used for adding links to graph to allow navigation to a module's subgraph by clicking on a module. If no `repoRootUrl` is provided, then links aren't added to the graph.<br>**Note**: Github doesn't support click navigation from mermaid graphs at the moment.|`main`|
+|`graphDirection`| `Direction` | `Direction.LeftToRight` | The direction in which the graph should be laid out.<br>Options: <ul> <li><code>Direction.LeftToRight</code></li> <li><code>Direction.TopToBottom</code></li> <li><code>Direction.BottomToTop</code></li> <li><code>Direction.RightToLeft</code></li> </ul> |
+| `showLegend` | `ShowLegend` | `ShowLegend.OnlyInRootGraph` | Whether to show a legend. When enabled, the graph with contain a legend identifying different types of modules — current/root, java/kotlin, Android and multiplatform — and different type of dependencies - direct, indirect & transitive.<br> Options: <ul> <li><code>ShowLegend.Always</code></li> <li><code>ShowLegend.OnlyInRootGraph</code></li> <li><code>ShowLegend.Never</code></li> </ul>|
+| `graphFileName` | `String` |  `dependencyGraph.md` | Name of the file in which the graph is saved. <br> **Note**: <!--<ul> <li>-->If the provided filename does not end in `.md`, then the extension will be appended. <!--</li><li>Try not to use `-` or any special characters in the file name. This interferes with the mermaid graph format when adding links. If the file name contains anything other than `[a-zA-Z0-9]`, then links will not be added.</li> </ul>-->|
+|`ignoreModules`|`List<String>`| `emptyList()` | A list of modules to be ignored when generating the graph. This may be used, for instance to remove system test modules to see only the production graph.<br>Provide the full path of the modules you want to ignore, e.g. `:live-feature:ui` instead of `:test-ui`. |
+| `shouldLinkModuleText` | `Boolean` |  `true` | Whether to add sub-graph links to module names in graphs. The links are useful for quickly navigating between graphs and sub-graphs.<br>**Note**: For links to work `repoRootUrl` and `mainBranchName` need to be provided |
+| `repoRootUrl` | `String` | `""` | Github URL for your repository. E.g. `https://github.com/adityabhaskar/Gradle-dependency-graphs`<br>The URL is used for adding links to modules to allow navigation to a module's subgraph just by clicking on it. If no URL is provided, then links are not added to the graph.<!--<br>**Note**: Github does not support click navigation from mermaid graphs at the moment.-->|
+| `mainBranchName`| `String` |`main`| Name of your main branch, e.g. `master`.<br>This is combined with the `repoRootUrl` to create clickable URLs. The URLs are used for adding links to graph to allow navigation to a module's subgraph by clicking on a module. If no `repoRootUrl` is provided, then links are not added to the graph.<!--<br>**Note**: Github does not support click navigation from mermaid graphs at the moment.-->|
 
 ## Dependency graphs
 

--- a/dependencyGraph.md
+++ b/dependencyGraph.md
@@ -48,6 +48,4 @@ end
 :example:domain--->:example:data
 
 %% Dependents
-
-%% Click interactions
 ```

--- a/dependencyGraph.md
+++ b/dependencyGraph.md
@@ -32,11 +32,11 @@ end
 %% Modules
 subgraph  
   direction LR;
-  :example:data{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md'>:example:data</a>}}:::javaNode;
-  :example:domain{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md'>:example:domain</a>}}:::javaNode;
-  :example:feature[<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md'>:example:feature</a>]:::javaNode;
-  :example:models{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md'>:example:models</a>}}:::javaNode;
-  :example:ui{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md'>:example:ui</a>}}:::javaNode;
+  :example:data{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:data</a>}}:::javaNode;
+  :example:domain{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:domain</a>}}:::javaNode;
+  :example:feature[<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:feature</a>]:::javaNode;
+  :example:models{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:models</a>}}:::javaNode;
+  :example:ui{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:ui</a>}}:::javaNode;
 end
 
 %% Dependencies

--- a/dependencyGraph.md
+++ b/dependencyGraph.md
@@ -32,11 +32,11 @@ end
 %% Modules
 subgraph  
   direction LR;
-  :example:data{{:example:data}}:::javaNode;
-  :example:domain{{:example:domain}}:::javaNode;
-  :example:feature[:example:feature]:::javaNode;
-  :example:models{{:example:models}}:::javaNode;
-  :example:ui{{:example:ui}}:::javaNode;
+  :example:data{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md">:example:data</a>}}:::javaNode;
+  :example:domain{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md">:example:domain</a>}}:::javaNode;
+  :example:feature[<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md">:example:feature</a>]:::javaNode;
+  :example:models{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md">:example:models</a>}}:::javaNode;
+  :example:ui{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md">:example:ui</a>}}:::javaNode;
 end
 
 %% Dependencies
@@ -50,9 +50,4 @@ end
 %% Dependents
 
 %% Click interactions
-click :example:data https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md
-click :example:domain https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md
-click :example:feature https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md
-click :example:models https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md
-click :example:ui https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md
 ```

--- a/dependencyGraph.md
+++ b/dependencyGraph.md
@@ -32,11 +32,11 @@ end
 %% Modules
 subgraph  
   direction LR;
-  :example:data{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md">:example:data</a>}}:::javaNode;
-  :example:domain{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md">:example:domain</a>}}:::javaNode;
-  :example:feature[<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md">:example:feature</a>]:::javaNode;
-  :example:models{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md">:example:models</a>}}:::javaNode;
-  :example:ui{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md">:example:ui</a>}}:::javaNode;
+  :example:data{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md'>:example:data</a>}}:::javaNode;
+  :example:domain{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md'>:example:domain</a>}}:::javaNode;
+  :example:feature[<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md'>:example:feature</a>]:::javaNode;
+  :example:models{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md'>:example:models</a>}}:::javaNode;
+  :example:ui{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md'>:example:ui</a>}}:::javaNode;
 end
 
 %% Dependencies

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -13,7 +13,7 @@ dependencyGraphConfig {
     mainBranchName.set("main")
 
     // Optional
-    graphFileName.set("dependency-graph.md")
+    graphFileName.set("dependencyGraph.md")
 
     // Optional
     graphDirection.set(Direction.LeftToRight)

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -23,4 +23,7 @@ dependencyGraphConfig {
 
     // Optional
     ignoreModules.set(listOf(":example:system-test"))
+
+    // Optional
+    shouldLinkNodeText.set(true)
 }

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -13,7 +13,7 @@ dependencyGraphConfig {
     mainBranchName.set("main")
 
     // Optional
-    graphFileName.set("dependencyGraph.md")
+    graphFileName.set("dependency-graph.md")
 
     // Optional
     graphDirection.set(Direction.LeftToRight)

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -25,5 +25,5 @@ dependencyGraphConfig {
     ignoreModules.set(listOf(":example:system-test"))
 
     // Optional
-    shouldLinkNodeText.set(true)
+    shouldLinkModuleText.set(true)
 }

--- a/example/data/dependencyGraph.md
+++ b/example/data/dependencyGraph.md
@@ -11,9 +11,9 @@ classDef javaNode fill:#ffb3ba;
 %% Modules
 subgraph  
   direction LR;
-  :example:data[<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md'>:example:data</a>]:::javaNode;
-  :example:domain{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md'>:example:domain</a>}}:::javaNode;
-  :example:models{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md'>:example:models</a>}}:::javaNode;
+  :example:data[<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:data</a>]:::javaNode;
+  :example:domain{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:domain</a>}}:::javaNode;
+  :example:models{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:models</a>}}:::javaNode;
 end
 
 %% Dependencies

--- a/example/data/dependencyGraph.md
+++ b/example/data/dependencyGraph.md
@@ -11,9 +11,9 @@ classDef javaNode fill:#ffb3ba;
 %% Modules
 subgraph  
   direction LR;
-  :example:data[:example:data]:::javaNode;
-  :example:domain{{:example:domain}}:::javaNode;
-  :example:models{{:example:models}}:::javaNode;
+  :example:data[<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md">:example:data</a>]:::javaNode;
+  :example:domain{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md">:example:domain</a>}}:::javaNode;
+  :example:models{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md">:example:models</a>}}:::javaNode;
 end
 
 %% Dependencies
@@ -23,7 +23,4 @@ end
 :example:domain-.->:example:data
 
 %% Click interactions
-click :example:data https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md
-click :example:domain https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md
-click :example:models https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md
 ```

--- a/example/data/dependencyGraph.md
+++ b/example/data/dependencyGraph.md
@@ -11,9 +11,9 @@ classDef javaNode fill:#ffb3ba;
 %% Modules
 subgraph  
   direction LR;
-  :example:data[<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md">:example:data</a>]:::javaNode;
-  :example:domain{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md">:example:domain</a>}}:::javaNode;
-  :example:models{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md">:example:models</a>}}:::javaNode;
+  :example:data[<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md'>:example:data</a>]:::javaNode;
+  :example:domain{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md'>:example:domain</a>}}:::javaNode;
+  :example:models{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md'>:example:models</a>}}:::javaNode;
 end
 
 %% Dependencies

--- a/example/data/dependencyGraph.md
+++ b/example/data/dependencyGraph.md
@@ -21,6 +21,4 @@ end
 
 %% Dependents
 :example:domain-.->:example:data
-
-%% Click interactions
 ```

--- a/example/domain/dependencyGraph.md
+++ b/example/domain/dependencyGraph.md
@@ -11,10 +11,10 @@ classDef javaNode fill:#ffb3ba;
 %% Modules
 subgraph  
   direction LR;
-  :example:data{{:example:data}}:::javaNode;
-  :example:domain[:example:domain]:::javaNode;
-  :example:feature{{:example:feature}}:::javaNode;
-  :example:models{{:example:models}}:::javaNode;
+  :example:data{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md">:example:data</a>}}:::javaNode;
+  :example:domain[<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md">:example:domain</a>]:::javaNode;
+  :example:feature{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md">:example:feature</a>}}:::javaNode;
+  :example:models{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md">:example:models</a>}}:::javaNode;
 end
 
 %% Dependencies
@@ -26,8 +26,4 @@ end
 :example:feature-.->:example:domain
 
 %% Click interactions
-click :example:data https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md
-click :example:domain https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md
-click :example:feature https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md
-click :example:models https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md
 ```

--- a/example/domain/dependencyGraph.md
+++ b/example/domain/dependencyGraph.md
@@ -11,10 +11,10 @@ classDef javaNode fill:#ffb3ba;
 %% Modules
 subgraph  
   direction LR;
-  :example:data{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md">:example:data</a>}}:::javaNode;
-  :example:domain[<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md">:example:domain</a>]:::javaNode;
-  :example:feature{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md">:example:feature</a>}}:::javaNode;
-  :example:models{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md">:example:models</a>}}:::javaNode;
+  :example:data{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md'>:example:data</a>}}:::javaNode;
+  :example:domain[<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md'>:example:domain</a>]:::javaNode;
+  :example:feature{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md'>:example:feature</a>}}:::javaNode;
+  :example:models{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md'>:example:models</a>}}:::javaNode;
 end
 
 %% Dependencies

--- a/example/domain/dependencyGraph.md
+++ b/example/domain/dependencyGraph.md
@@ -24,6 +24,4 @@ end
 
 %% Dependents
 :example:feature-.->:example:domain
-
-%% Click interactions
 ```

--- a/example/domain/dependencyGraph.md
+++ b/example/domain/dependencyGraph.md
@@ -11,10 +11,10 @@ classDef javaNode fill:#ffb3ba;
 %% Modules
 subgraph  
   direction LR;
-  :example:data{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md'>:example:data</a>}}:::javaNode;
-  :example:domain[<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md'>:example:domain</a>]:::javaNode;
-  :example:feature{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md'>:example:feature</a>}}:::javaNode;
-  :example:models{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md'>:example:models</a>}}:::javaNode;
+  :example:data{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:data</a>}}:::javaNode;
+  :example:domain[<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:domain</a>]:::javaNode;
+  :example:feature{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:feature</a>}}:::javaNode;
+  :example:models{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:models</a>}}:::javaNode;
 end
 
 %% Dependencies

--- a/example/feature/dependencyGraph.md
+++ b/example/feature/dependencyGraph.md
@@ -27,6 +27,4 @@ end
 :example:domain--->:example:data
 
 %% Dependents
-
-%% Click interactions
 ```

--- a/example/feature/dependencyGraph.md
+++ b/example/feature/dependencyGraph.md
@@ -11,11 +11,11 @@ classDef javaNode fill:#ffb3ba;
 %% Modules
 subgraph  
   direction LR;
-  :example:data{{:example:data}}:::javaNode;
-  :example:domain{{:example:domain}}:::javaNode;
-  :example:feature[:example:feature]:::javaNode;
-  :example:models{{:example:models}}:::javaNode;
-  :example:ui{{:example:ui}}:::javaNode;
+  :example:data{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md">:example:data</a>}}:::javaNode;
+  :example:domain{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md">:example:domain</a>}}:::javaNode;
+  :example:feature[<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md">:example:feature</a>]:::javaNode;
+  :example:models{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md">:example:models</a>}}:::javaNode;
+  :example:ui{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md">:example:ui</a>}}:::javaNode;
 end
 
 %% Dependencies
@@ -29,9 +29,4 @@ end
 %% Dependents
 
 %% Click interactions
-click :example:data https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md
-click :example:domain https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md
-click :example:feature https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md
-click :example:models https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md
-click :example:ui https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md
 ```

--- a/example/feature/dependencyGraph.md
+++ b/example/feature/dependencyGraph.md
@@ -11,11 +11,11 @@ classDef javaNode fill:#ffb3ba;
 %% Modules
 subgraph  
   direction LR;
-  :example:data{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md'>:example:data</a>}}:::javaNode;
-  :example:domain{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md'>:example:domain</a>}}:::javaNode;
-  :example:feature[<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md'>:example:feature</a>]:::javaNode;
-  :example:models{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md'>:example:models</a>}}:::javaNode;
-  :example:ui{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md'>:example:ui</a>}}:::javaNode;
+  :example:data{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:data</a>}}:::javaNode;
+  :example:domain{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:domain</a>}}:::javaNode;
+  :example:feature[<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:feature</a>]:::javaNode;
+  :example:models{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:models</a>}}:::javaNode;
+  :example:ui{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:ui</a>}}:::javaNode;
 end
 
 %% Dependencies

--- a/example/feature/dependencyGraph.md
+++ b/example/feature/dependencyGraph.md
@@ -11,11 +11,11 @@ classDef javaNode fill:#ffb3ba;
 %% Modules
 subgraph  
   direction LR;
-  :example:data{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md">:example:data</a>}}:::javaNode;
-  :example:domain{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md">:example:domain</a>}}:::javaNode;
-  :example:feature[<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md">:example:feature</a>]:::javaNode;
-  :example:models{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md">:example:models</a>}}:::javaNode;
-  :example:ui{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md">:example:ui</a>}}:::javaNode;
+  :example:data{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md'>:example:data</a>}}:::javaNode;
+  :example:domain{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md'>:example:domain</a>}}:::javaNode;
+  :example:feature[<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md'>:example:feature</a>]:::javaNode;
+  :example:models{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md'>:example:models</a>}}:::javaNode;
+  :example:ui{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md'>:example:ui</a>}}:::javaNode;
 end
 
 %% Dependencies

--- a/example/models/dependencyGraph.md
+++ b/example/models/dependencyGraph.md
@@ -11,10 +11,10 @@ classDef javaNode fill:#ffb3ba;
 %% Modules
 subgraph  
   direction LR;
-  :example:data{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md">:example:data</a>}}:::javaNode;
-  :example:domain{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md">:example:domain</a>}}:::javaNode;
-  :example:models[<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md">:example:models</a>]:::javaNode;
-  :example:ui{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md">:example:ui</a>}}:::javaNode;
+  :example:data{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md'>:example:data</a>}}:::javaNode;
+  :example:domain{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md'>:example:domain</a>}}:::javaNode;
+  :example:models[<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md'>:example:models</a>]:::javaNode;
+  :example:ui{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md'>:example:ui</a>}}:::javaNode;
 end
 
 %% Dependencies

--- a/example/models/dependencyGraph.md
+++ b/example/models/dependencyGraph.md
@@ -11,10 +11,10 @@ classDef javaNode fill:#ffb3ba;
 %% Modules
 subgraph  
   direction LR;
-  :example:data{{:example:data}}:::javaNode;
-  :example:domain{{:example:domain}}:::javaNode;
-  :example:models[:example:models]:::javaNode;
-  :example:ui{{:example:ui}}:::javaNode;
+  :example:data{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md">:example:data</a>}}:::javaNode;
+  :example:domain{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md">:example:domain</a>}}:::javaNode;
+  :example:models[<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md">:example:models</a>]:::javaNode;
+  :example:ui{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md">:example:ui</a>}}:::javaNode;
 end
 
 %% Dependencies
@@ -25,8 +25,4 @@ end
 :example:domain-.API.->:example:models
 
 %% Click interactions
-click :example:data https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md
-click :example:domain https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md
-click :example:models https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md
-click :example:ui https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md
 ```

--- a/example/models/dependencyGraph.md
+++ b/example/models/dependencyGraph.md
@@ -11,10 +11,10 @@ classDef javaNode fill:#ffb3ba;
 %% Modules
 subgraph  
   direction LR;
-  :example:data{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md'>:example:data</a>}}:::javaNode;
-  :example:domain{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md'>:example:domain</a>}}:::javaNode;
-  :example:models[<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md'>:example:models</a>]:::javaNode;
-  :example:ui{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md'>:example:ui</a>}}:::javaNode;
+  :example:data{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/data/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:data</a>}}:::javaNode;
+  :example:domain{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/domain/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:domain</a>}}:::javaNode;
+  :example:models[<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:models</a>]:::javaNode;
+  :example:ui{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:ui</a>}}:::javaNode;
 end
 
 %% Dependencies

--- a/example/models/dependencyGraph.md
+++ b/example/models/dependencyGraph.md
@@ -23,6 +23,4 @@ end
 :example:data-.->:example:models
 :example:ui-.->:example:models
 :example:domain-.API.->:example:models
-
-%% Click interactions
 ```

--- a/example/ui/dependencyGraph.md
+++ b/example/ui/dependencyGraph.md
@@ -11,9 +11,9 @@ classDef javaNode fill:#ffb3ba;
 %% Modules
 subgraph  
   direction LR;
-  :example:feature{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md'>:example:feature</a>}}:::javaNode;
-  :example:models{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md'>:example:models</a>}}:::javaNode;
-  :example:ui[<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md'>:example:ui</a>]:::javaNode;
+  :example:feature{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:feature</a>}}:::javaNode;
+  :example:models{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:models</a>}}:::javaNode;
+  :example:ui[<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md' style='color:#333;text-decoration:auto;'>:example:ui</a>]:::javaNode;
 end
 
 %% Dependencies

--- a/example/ui/dependencyGraph.md
+++ b/example/ui/dependencyGraph.md
@@ -11,9 +11,9 @@ classDef javaNode fill:#ffb3ba;
 %% Modules
 subgraph  
   direction LR;
-  :example:feature{{:example:feature}}:::javaNode;
-  :example:models{{:example:models}}:::javaNode;
-  :example:ui[:example:ui]:::javaNode;
+  :example:feature{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md">:example:feature</a>}}:::javaNode;
+  :example:models{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md">:example:models</a>}}:::javaNode;
+  :example:ui[<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md">:example:ui</a>]:::javaNode;
 end
 
 %% Dependencies
@@ -23,7 +23,4 @@ end
 :example:feature-.->:example:ui
 
 %% Click interactions
-click :example:feature https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md
-click :example:models https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md
-click :example:ui https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md
 ```

--- a/example/ui/dependencyGraph.md
+++ b/example/ui/dependencyGraph.md
@@ -11,9 +11,9 @@ classDef javaNode fill:#ffb3ba;
 %% Modules
 subgraph  
   direction LR;
-  :example:feature{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md">:example:feature</a>}}:::javaNode;
-  :example:models{{<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md">:example:models</a>}}:::javaNode;
-  :example:ui[<a href="https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md">:example:ui</a>]:::javaNode;
+  :example:feature{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/feature/dependencyGraph.md'>:example:feature</a>}}:::javaNode;
+  :example:models{{<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/models/dependencyGraph.md'>:example:models</a>}}:::javaNode;
+  :example:ui[<a href='https://github.com/adityabhaskar/Gradle-dependency-graphs/blob/main/example/ui/dependencyGraph.md'>:example:ui</a>]:::javaNode;
 end
 
 %% Dependencies

--- a/example/ui/dependencyGraph.md
+++ b/example/ui/dependencyGraph.md
@@ -21,6 +21,4 @@ end
 
 %% Dependents
 :example:feature-.->:example:ui
-
-%% Click interactions
 ```

--- a/plugin-build/gradle.properties
+++ b/plugin-build/gradle.properties
@@ -1,5 +1,5 @@
 ID=io.github.adityabhaskar.dependencygraph
-VERSION=0.1.2
+VERSION=0.1.3
 GROUP=io.github.adityabhaskar
 DISPLAY_NAME=Gradle module dependency graphs
 DESCRIPTION=A plugin to automatically produce Github/mermaid compatible dependency graphs

--- a/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/DependencyGraphExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/DependencyGraphExtension.kt
@@ -54,7 +54,7 @@ abstract class DependencyGraphExtension @Inject constructor(project: Project) {
      * Github doesn't support click navigation from mermaid graphs at the moment. Linking the text
      * instead provides a work around for allowing navigating between subgraphs.
      */
-    val shouldLinkNodeText: Property<Boolean> = objects.property(Boolean::class.java)
+    val shouldLinkModuleText: Property<Boolean> = objects.property(Boolean::class.java)
 
     /**
      * Optional setting to define whether to show a legend identifying different types of modules.

--- a/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/DependencyGraphExtension.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/DependencyGraphExtension.kt
@@ -45,12 +45,16 @@ abstract class DependencyGraphExtension @Inject constructor(project: Project) {
     /**
      * Optional name for the file where graph is saved. Default is `dependencyGraph.md`.
      * If the provided filename doesn't end in `.md`, then the extension will be appended.
-     *
-     * **NOTE**: Try to not use `-` or any special characters in the file name. This interferes
-     * with graph format when adding links. If the file name contains anything other than
-     * `[a-zA-Z0-9]`, then links will not be added.
      */
     val graphFileName: Property<String> = objects.property(String::class.java)
+
+    /**
+     * Whether module name text should link to graphs for that module.
+     *
+     * Github doesn't support click navigation from mermaid graphs at the moment. Linking the text
+     * instead provides a work around for allowing navigating between subgraphs.
+     */
+    val shouldLinkNodeText: Property<Boolean> = objects.property(Boolean::class.java)
 
     /**
      * Optional setting to define whether to show a legend identifying different types of modules.

--- a/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/DependencyGraphPlugin.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/DependencyGraphPlugin.kt
@@ -21,6 +21,7 @@ abstract class DependencyGraphPlugin : Plugin<Project> {
             it.repoRootUrl.set(extension.repoRootUrl)
             it.graphDirection.set(extension.graphDirection)
             it.showLegend.set(extension.showLegend)
+            it.shouldLinkNodeText.set(extension.shouldLinkNodeText)
 
             it.parsedGraph.set(
                 parseDependencyGraph(

--- a/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/DependencyGraphPlugin.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/DependencyGraphPlugin.kt
@@ -21,7 +21,7 @@ abstract class DependencyGraphPlugin : Plugin<Project> {
             it.repoRootUrl.set(extension.repoRootUrl)
             it.graphDirection.set(extension.graphDirection)
             it.showLegend.set(extension.showLegend)
-            it.shouldLinkNodeText.set(extension.shouldLinkNodeText)
+            it.shouldLinkModuleText.set(extension.shouldLinkModuleText)
 
             it.parsedGraph.set(
                 parseDependencyGraph(

--- a/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/DependencyGraphTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/DependencyGraphTask.kt
@@ -149,14 +149,10 @@ abstract class DependencyGraphTask : DefaultTask() {
         val fileName = appendMarkDownIfNeeded(
             providedFileName = graphFileName.getOrElse(DEFAULT_GRAPH_FILE_NAME),
         )
-        val moduleBaseUrl = if (doesFileNameSupportLinks(fileName)) {
-            createGraphUrl(
-                repoUrl = repoRootUrl.orNull,
-                mainBranchName = mainBranchName.orNull,
-            )
-        } else {
-            null
-        }
+        val moduleBaseUrl = createGraphUrl(
+            repoUrl = repoRootUrl.orNull,
+            mainBranchName = mainBranchName.orNull,
+        )
 
         // Draw sub graph of dependencies and dependents for each module
         graph.projects.forEach {
@@ -202,9 +198,6 @@ abstract class DependencyGraphTask : DefaultTask() {
             "$repoUrl/blob/$branchName"
         }
     }
-
-    private fun doesFileNameSupportLinks(fileName: String) =
-        Regex("[a-zA-Z0-9]+\\.[a-zA-Z0-9]+").matches(fileName)
 
     private fun appendMarkDownIfNeeded(providedFileName: String) = when {
         providedFileName.isBlank() -> DEFAULT_GRAPH_FILE_NAME

--- a/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/DependencyGraphTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/DependencyGraphTask.kt
@@ -167,6 +167,7 @@ abstract class DependencyGraphTask : DefaultTask() {
             repoUrl = repoRootUrl.orNull,
             mainBranchName = mainBranchName.orNull,
         )
+        val shouldLinkNodeText = shouldLinkNodeText.getOrElse(true)
 
         // Draw sub graph of dependencies and dependents for each module
         graph.projects.forEach {
@@ -180,6 +181,7 @@ abstract class DependencyGraphTask : DefaultTask() {
                     showLegend = showLegend,
                     graphDirection = directionString,
                     fileName = fileName,
+                    shouldLinkNodeText = shouldLinkNodeText,
                 ),
             )
         }
@@ -195,6 +197,7 @@ abstract class DependencyGraphTask : DefaultTask() {
                 showLegend = showLegend,
                 graphDirection = directionString,
                 fileName = fileName,
+                shouldLinkNodeText = shouldLinkNodeText,
             ),
         )
     }

--- a/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/DependencyGraphTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/DependencyGraphTask.kt
@@ -99,6 +99,20 @@ abstract class DependencyGraphTask : DefaultTask() {
     @get:Optional
     abstract val graphDirection: Property<Direction>
 
+    /**
+     * Whether module name text should link to graphs for that module.
+     *
+     * Github doesn't support click navigation from mermaid graphs at the moment. Linking the text
+     * instead provides a work around for allowing navigating between subgraphs.
+     */
+    @get:Input
+    @get:Option(
+        option = "shouldLinkNodeText",
+        description = "Whether module name text should link to graphs for that module",
+    )
+    @get:Optional
+    abstract val shouldLinkNodeText: Property<Boolean>
+
     /** Whether and where a legend should be displayed. */
     @get:Input
     @get:Option(

--- a/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/DependencyGraphTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/DependencyGraphTask.kt
@@ -107,11 +107,11 @@ abstract class DependencyGraphTask : DefaultTask() {
      */
     @get:Input
     @get:Option(
-        option = "shouldLinkNodeText",
+        option = "shouldLinkModuleText",
         description = "Whether module name text should link to graphs for that module",
     )
     @get:Optional
-    abstract val shouldLinkNodeText: Property<Boolean>
+    abstract val shouldLinkModuleText: Property<Boolean>
 
     /** Whether and where a legend should be displayed. */
     @get:Input
@@ -167,7 +167,7 @@ abstract class DependencyGraphTask : DefaultTask() {
             repoUrl = repoRootUrl.orNull,
             mainBranchName = mainBranchName.orNull,
         )
-        val shouldLinkNodeText = shouldLinkNodeText.getOrElse(true)
+        val shouldLinkModuleText = shouldLinkModuleText.getOrElse(true)
 
         // Draw sub graph of dependencies and dependents for each module
         graph.projects.forEach {
@@ -181,7 +181,7 @@ abstract class DependencyGraphTask : DefaultTask() {
                     showLegend = showLegend,
                     graphDirection = directionString,
                     fileName = fileName,
-                    shouldLinkNodeText = shouldLinkNodeText,
+                    shouldLinkModuleText = shouldLinkModuleText,
                 ),
             )
         }
@@ -197,7 +197,7 @@ abstract class DependencyGraphTask : DefaultTask() {
                 showLegend = showLegend,
                 graphDirection = directionString,
                 fileName = fileName,
-                shouldLinkNodeText = shouldLinkNodeText,
+                shouldLinkModuleText = shouldLinkModuleText,
             ),
         )
     }

--- a/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/core/DrawGraph.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/core/DrawGraph.kt
@@ -109,7 +109,7 @@ internal fun drawDependencyGraph(
         val relativePath = project.projectDir.relativeTo(config.rootDir)
         val nodeText = config.moduleBaseUrl?.let {
             val link = "$it/$relativePath/${config.fileName}"
-            "<a href='$link'>${project.path}</a>"
+            "<a href='$link' style='color:#333;text-decoration:auto;'>${project.path}</a>"
         } ?: project.path
 
         fileText += "  ${project.path}${nodeStart}${nodeText}${nodeEnd}$nodeClass;\n"

--- a/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/core/DrawGraph.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/core/DrawGraph.kt
@@ -112,7 +112,7 @@ internal fun drawDependencyGraph(
         val text = config.moduleBaseUrl?.let {
 //            clickText += "click ${project.path} $it/$relativePath/${config.fileName}\n"
             val link = "$it/$relativePath/${config.fileName}"
-            "<a href=\"$link\">${project.path}</a>"
+            "<a href='$link'>${project.path}</a>"
         } ?: project.path
 
         fileText += "  ${project.path}${nodeStart}${text}${nodeEnd}$nodeClass;\n"

--- a/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/core/DrawGraph.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/core/DrawGraph.kt
@@ -12,6 +12,7 @@ internal data class DrawConfig(
     val showLegend: ShowLegend,
     val graphDirection: String,
     val fileName: String,
+    val shouldLinkNodeText: Boolean,
 )
 
 @Suppress("LongMethod", "CyclomaticComplexMethod", "CognitiveComplexMethod", "ktlint:indent")
@@ -107,10 +108,12 @@ internal fun drawDependencyGraph(
         }
 
         val relativePath = project.projectDir.relativeTo(config.rootDir)
-        val nodeText = config.moduleBaseUrl?.let {
-            val link = "$it/$relativePath/${config.fileName}"
+        val nodeText = if (config.shouldLinkNodeText && config.moduleBaseUrl != null) {
+            val link = "${config.moduleBaseUrl}/$relativePath/${config.fileName}"
             "<a href='$link' style='color:#333;text-decoration:auto;'>${project.path}</a>"
-        } ?: project.path
+        } else {
+            project.path
+        }
 
         fileText += "  ${project.path}${nodeStart}${nodeText}${nodeEnd}$nodeClass;\n"
     }

--- a/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/core/DrawGraph.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/core/DrawGraph.kt
@@ -12,7 +12,7 @@ internal data class DrawConfig(
     val showLegend: ShowLegend,
     val graphDirection: String,
     val fileName: String,
-    val shouldLinkNodeText: Boolean,
+    val shouldLinkModuleText: Boolean,
 )
 
 @Suppress("LongMethod", "CyclomaticComplexMethod", "CognitiveComplexMethod", "ktlint:indent")
@@ -108,7 +108,7 @@ internal fun drawDependencyGraph(
         }
 
         val relativePath = project.projectDir.relativeTo(config.rootDir)
-        val nodeText = if (config.shouldLinkNodeText && config.moduleBaseUrl != null) {
+        val nodeText = if (config.shouldLinkModuleText && config.moduleBaseUrl != null) {
             val link = "${config.moduleBaseUrl}/$relativePath/${config.fileName}"
             "<a href='$link' style='color:#333;text-decoration:auto;'>${project.path}</a>"
         } else {

--- a/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/core/DrawGraph.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/core/DrawGraph.kt
@@ -108,12 +108,14 @@ internal fun drawDependencyGraph(
             ""
         }
 
-        fileText += "  ${project.path}${nodeStart}${project.path}${nodeEnd}$nodeClass;\n"
-
         val relativePath = project.projectDir.relativeTo(config.rootDir)
-        config.moduleBaseUrl?.let {
-            clickText += "click ${project.path} $it/$relativePath/${config.fileName}\n"
-        }
+        val text = config.moduleBaseUrl?.let {
+//            clickText += "click ${project.path} $it/$relativePath/${config.fileName}\n"
+            val link = "$it/$relativePath/${config.fileName}"
+            "<a href=\"$link\">${project.path}</a>"
+        } ?: project.path
+
+        fileText += "  ${project.path}${nodeStart}${text}${nodeEnd}$nodeClass;\n"
     }
 
     fileText += """

--- a/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/core/DrawGraph.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/core/DrawGraph.kt
@@ -68,8 +68,6 @@ internal fun drawDependencyGraph(
     val javaNodeStart = "{{"
     val javaNodeEnd = "}}"
 
-    var clickText = ""
-
     for (project in projects) {
         if (
             !isRootGraph &&
@@ -109,13 +107,12 @@ internal fun drawDependencyGraph(
         }
 
         val relativePath = project.projectDir.relativeTo(config.rootDir)
-        val text = config.moduleBaseUrl?.let {
-//            clickText += "click ${project.path} $it/$relativePath/${config.fileName}\n"
+        val nodeText = config.moduleBaseUrl?.let {
             val link = "$it/$relativePath/${config.fileName}"
             "<a href='$link'>${project.path}</a>"
         } ?: project.path
 
-        fileText += "  ${project.path}${nodeStart}${text}${nodeEnd}$nodeClass;\n"
+        fileText += "  ${project.path}${nodeStart}${nodeText}${nodeEnd}$nodeClass;\n"
     }
 
     fileText += """
@@ -170,15 +167,7 @@ internal fun drawDependencyGraph(
             fileText += "${origin.path}${arrow}${target.path}\n"
         }
 
-    fileText += if (config.moduleBaseUrl == null) {
-        "```"
-    } else {
-        """
-
-%% Click interactions
-$clickText```
-""".trimIndent()
-    }
+    fileText += "```"
 
     val graphFile = File(currentProject.projectDir, config.fileName)
     graphFile.parentFile.mkdirs()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Since Github doesn't support node level links in mermaid (see https://github.com/orgs/community/discussions/46096), this is a work around to instead add links to node text - the module name.

Also added a config option to disable this behaviour if required - `shouldLinkModuleText`.