### PR TITLE
fix configuration cache problem 

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/DependencyGraphTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/DependencyGraphTask.kt
@@ -186,7 +186,7 @@ abstract class DependencyGraphTask : DefaultTask() {
                 parsedGraph = graph,
                 isRootGraph = false,
                 config = DrawConfig(
-                    rootDir = project.rootDir,
+                    rootDir = graph.rootProject.projectDir,
                     moduleBaseUrl = moduleBaseUrl,
                     showLegend = showLegend,
                     graphDirection = directionString,
@@ -199,11 +199,11 @@ abstract class DependencyGraphTask : DefaultTask() {
 
         // Draw the full graph of all modules
         drawDependencyGraph(
-            currentProject = project.rootProject.asModuleProject(),
+            currentProject = graph.rootProject,
             parsedGraph = graph,
             isRootGraph = true,
             config = DrawConfig(
-                rootDir = project.rootDir,
+                rootDir = graph.rootProject.projectDir,
                 moduleBaseUrl = moduleBaseUrl,
                 showLegend = showLegend,
                 graphDirection = directionString,

--- a/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/ParsedGraph.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/ParsedGraph.kt
@@ -10,6 +10,7 @@ internal data class ParsedGraph(
     val androidProjects: List<ModuleProject>,
     val javaProjects: List<ModuleProject>,
     val rootProjects: List<ModuleProject>,
+    val rootProject: ModuleProject,
 )
 
 internal data class DependencyPair(

--- a/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/core/ParseGraph.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/adityabhaskar/dependencygraph/plugin/core/ParseGraph.kt
@@ -120,5 +120,6 @@ internal fun parseDependencyGraph(
         androidProjects = androidProjects.map { it.asModuleProject() },
         javaProjects = javaProjects.map { it.asModuleProject() },
         rootProjects = rootProjects.map { it.asModuleProject() },
+        rootProject = rootProject.asModuleProject(),
     )
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

### What I did
I fixed configuration cache problem.  I updated that 

* `ParsedGraph` has `rootProject: ModuleProject`
* `DependencyGraphTask` doesn't have a reference `Task.project`

### Problem
When configuration cache is enabled like [this](https://github.com/hisakaz0/Gradle-dependency-graphs/commit/4329862d8c5af6a6e6fcf60e557d754cbf352e58), there are problems. Below is a part of build log.
```
FAILURE: Build failed with an exception.

* What went wrong:
Configuration cache problems found in this build.

18 problems were found storing the configuration cache, 1 of which seems unique.
- Task `:example:dependencyGraph` of type `io.github.adityabhaskar.dependencygraph.plugin.DependencyGraphTask`: invocation of 'Task.project' at execution time is unsupported.
  See https://docs.gradle.org/8.2.1/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution

See the complete report at file:///Users/hisakazu/Works/github/Gradle-dependency-graphs/build/reports/configuration-cache/dgund4ww2jcy6d4iw3el4i2pl/apdtvixg9k7aqvcw7osd4cyfe/configuration-cache-report.html
> Invocation of 'Task.project' by task ':example:dependencyGraph' at execution time is unsupported.
```

### Test
* [x] successfully run `dependencyGraph` task 
* [x] update dependency graph when dependency updated in build.gradle(configuration cache enabled)
